### PR TITLE
Update worker base image version to fix build

### DIFF
--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:artful-scm
+FROM buildpack-deps:bionic-scm
 
 RUN set -ex; \
 	apt-get update; \


### PR DESCRIPTION
As the Ubuntu artful version is not supported anymore the image build is not working. Updating base image to the latest Ubuntu LTS